### PR TITLE
Fix chart rendering in performance-management

### DIFF
--- a/app/elements/leaderboard/leaderboard.html
+++ b/app/elements/leaderboard/leaderboard.html
@@ -814,7 +814,8 @@
 				.innerTickSize(-width)
 				.outerTickSize(0);
 
-			this.root.querySelectorAll('.d3-tip')
+			// The d3-tip lives at the document level.
+			document.querySelectorAll('.d3-tip')
 							 .forEach(x => x.parentNode && x.parentNode.removeChild(x));
 
 			var tip = d3.tip()

--- a/app/elements/performance-management/performance-management.html
+++ b/app/elements/performance-management/performance-management.html
@@ -249,7 +249,8 @@
 				.innerTickSize(-this.width)
 				.outerTickSize(0);
 
-			this.root.querySelectorAll('.d3-tip')
+			// The d3-tip lives at the document level.
+			document.querySelectorAll('.d3-tip')
 							 .forEach(x => x.parentNode && x.parentNode.removeChild(x));
 
 			var tip = d3.tip()
@@ -438,7 +439,8 @@
 				.innerTickSize(-this.width)
 				.outerTickSize(0);
 
-			this.root.querySelectorAll('.d3-tip')
+			// The d3-tip lives at the document level.
+			document.querySelectorAll('.d3-tip')
 							 .forEach(x => x.parentNode && x.parentNode.removeChild(x));
 
 			var tip = d3.tip()

--- a/app/elements/performance-management/performance-management.html
+++ b/app/elements/performance-management/performance-management.html
@@ -365,7 +365,7 @@
 			if (time === 'weeks') {
 				/* unused: d */
 				bars.on('click', (d, i) => {
-					this.fillBars(barchart, 'days', i);
+					this.fillBars('days', i);
 				});
 			} else {
 				bars.on('click', (d, i) => {


### PR DESCRIPTION
The fillBars() function was refactored a couple times for D3 to
properly select the barchart in the element's template. One of those
refactorings was not completely removed, resulting in a reference to
an undefined variable in fillBars(), causing the drill-down in the
bar chart to fail and show up as blank.